### PR TITLE
tree选择bug(dev-cjp)

### DIFF
--- a/src/components/TemplateTree.vue
+++ b/src/components/TemplateTree.vue
@@ -72,9 +72,13 @@ export default {
     },
     handleClickNode(obj, node, dom) {},
     handleCheckChange(obj, isCheck, node) { // 勾选事件
-      this.$emit('check-change', isCheck, obj)
       if (isCheck) {
         this.$refs.tree.setCheckedKeys([obj.dbid], false);
+        this.$emit('check-change', isCheck, obj)
+      } else {
+        if (this.$refs.tree.getCheckedNodes().length < 1) {
+          this.$emit('check-change', isCheck, obj)
+        }
       }
     },
   },


### PR DESCRIPTION
选择A后,选择B时;首先先触发了选择B事件,然后出发了取消A选中事件
修改逻辑:取消选中时,判断出是'替换'还是'取消',替换不触发事件